### PR TITLE
Dont encode short strings w/ nil column in #quote

### DIFF
--- a/lib/active_record/connection_adapters/fb/quoting.rb
+++ b/lib/active_record/connection_adapters/fb/quoting.rb
@@ -13,7 +13,7 @@ module ActiveRecord
             if [:integer, :float].include?(type)
               value = type == :integer ? value.to_i : value.to_f
               value.to_s
-            elsif type && type != :binary && value.size < 256 && !value.include?('@')
+            elsif !(type && type == :binary) && value.size < 256 && !value.include?('@')
               "'#{quote_string(value)}'"
             else
               "@#{Base64.encode64(value).chop}@"

--- a/lib/active_record/connection_adapters/fb_column.rb
+++ b/lib/active_record/connection_adapters/fb_column.rb
@@ -49,7 +49,7 @@ module ActiveRecord
 
       def parse_default(default_source)
         default_source =~ /^\s*DEFAULT\s+(.*)\s*$/i
-        return $1 unless $1.nil? || $1.upcase == "NULL"
+        return $1 unless $1.upcase == "NULL"
       end
 
       def column_def

--- a/test/cases/add_column_test_fb.rb
+++ b/test/cases/add_column_test_fb.rb
@@ -26,4 +26,11 @@ class AddColumnTestFb < ActiveRecord::TestCase
     @connection.add_column :bicycles, :id, :primary_key, sequence: false
     assert !@raw.generator_names.include?('bicycles_seq')
   end
+
+  def test_blank_default
+    @connection.add_column :bicycles, :model, :string, default: ''
+    assert_equal '', @connection.columns('bicycles').find { |column|
+      column.name == 'model'
+    }.default
+  end
 end


### PR DESCRIPTION
The nil check didn't seem to fix the issue on 4.0.13. I think this issue was the result of a larger problem:

Here are the test results of my changes:

```
Before fix: 4556 runs, 11624 assertions, 66 failures, 64 errors, 0 skips
After fix:  4556 runs, 11628 assertions, 60 failures, 61 errors, 0 skips
```
